### PR TITLE
command: ensure script on Solo terminates on ssh disconnect

### DIFF
--- a/soloutils/__init__.py
+++ b/soloutils/__init__.py
@@ -61,6 +61,7 @@ def connect_solo(await=True, silent=False):
 
 def command_stream(client, cmd, stdout=sys.stdout, stderr=sys.stderr):
     chan = client.get_transport().open_session()
+    chan.get_pty()
     chan.exec_command(cmd)
     while True:
         time.sleep(0.1)


### PR DESCRIPTION
getting a pty ensures the scripts running on Solo have a
controlling tty and will get a SIGHUP when it gets disconnected

Without this you can accumulate running scripts on Solo
